### PR TITLE
Assign maintainership to @drivergroup/swe

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# Maintainers of this repository are listed here to determine
+# reviewers for pull requests.
+# 
+# See https://help.github.com/articles/about-codeowners/ for more
+# information on available features.
+
+# Default maintainers
+* @drivergroup/swe


### PR DESCRIPTION
This commit adds a CODEOWNERS file to the root directory of the
repository. The team responsible for this repository is listed in it,
and members will automatically be added as reviewers in future PRs.

See https://help.github.com/articles/about-codeowners/ for more
information on available features.

Note: I'm adding code owners to most of Driver's repos and including
teams who I think are the primary maintainers of the repository. I'm
doing this in bulk and may not always be accurate. Let me know if you
think the team given here should not be the maintainer. *Otherwise,
please feel free to merge (no need to give a thumbs up and wait for me
to merge it).*